### PR TITLE
Fix RouteServiceProvider::boot signature

### DIFF
--- a/src/RouteServiceProvider.php
+++ b/src/RouteServiceProvider.php
@@ -13,11 +13,11 @@ class RouteServiceProvider extends ServiceProvider
      * @param  \Illuminate\Routing\Router  $router
      * @return void
      */
-    public function boot()
+    public function boot(Router $router)
     {
         $this->loadConfig();
 
-        parent::boot();
+        parent::boot($router);
     }
 
     /**


### PR DESCRIPTION
Revert `RouteServiceProvider::boot` signature as it was to fix

```
[ErrorException]                                                                                                                      
  Declaration of Optimus\Api\System\RouteServiceProvider::boot() should be compatible with Illuminate\Foundation\Support\Providers\Rou  
  teServiceProvider::boot(Illuminate\Routing\Router $router) 
```

on `php artisan clear-compiled`
