### PR TITLE
Individual providers for Laravel 5.2 and 5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,11 @@ Some service providers to enable a Laravel project structure that is grouped by 
 ```bash
 composer require optimus/distributed-laravel 0.1.*
 ```
+
+### Laravel 5.2
+
+`Optimus\Api\System\Laravel52RouteServiceProvider`
+
+### Laravel 5.3
+
+`Optimus\Api\System\Laravel53RouteServiceProvider`

--- a/src/Laravel52RouteServiceProvider.php
+++ b/src/Laravel52RouteServiceProvider.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Optimus\Api\System;
+
+use Illuminate\Routing\Router;
+
+abstract class Laravel52RouteServiceProvider extends Providers\RouteServiceProvider
+{
+    /**
+     * Bootstrap any application services.
+     *
+     * @return void
+     */
+    public function boot(Router $router)
+    {
+        $this->loadConfig();
+
+        parent::boot($router);
+    }
+}

--- a/src/Laravel53RouteServiceProvider.php
+++ b/src/Laravel53RouteServiceProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Optimus\Api\System;
+
+abstract class Laravel53RouteServiceProvider extends Providers\RouteServiceProvider
+{
+    /**
+     * Bootstrap any application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $this->loadConfig();
+
+        parent::boot();
+    }
+}

--- a/src/Options/Config.php
+++ b/src/Options/Config.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Optimus\Api\System\Options;
+
+class Config extends Options
+{
+    /**
+     * Defaults
+     *
+     * @var array
+     */
+    protected $defaults = [
+        'namespaces' => [],
+
+        'middleware' => [],
+
+        'protection_middleware' => [],
+
+        'resource_namespace' => 'resources',
+
+        'language_folder_name' => 'lang',
+
+        'view_folder_name' => 'views',
+    ];
+}

--- a/src/Options/Options.php
+++ b/src/Options/Options.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Optimus\Api\System\Options;
+
+class Options
+{
+    /** @var array */
+    protected $defaults = [];
+
+    /** @var array */
+    protected $options = [];
+
+    public function __construct(array $options = [])
+    {
+        $this->options = $this->mergeAssociative($this->defaults, $options);
+    }
+
+    /**
+     * Merge associative array
+     *
+     * @param array $a
+     * @param array $b
+     * @return array
+     */
+    public function mergeAssociative(array $a, array $b)
+    {
+        $mergedArray = $a;
+
+        foreach ($b as $k => $v) {
+            $mergedArray[$k] = $v;
+
+            if (is_array($v) && isset($a[$k]) && is_array($a[$k])) {
+                $mergedArray[$k] = $this->mergeAssociative($a[$k], $v);
+            }
+        }
+
+        return $mergedArray;
+    }
+
+    /**
+     * @return array
+     */
+    public function getDefaults()
+    {
+        return $this->defaults;
+    }
+
+    /**
+     * @param array $defaults
+     */
+    public function setDefaults(array $defaults)
+    {
+        $this->defaults = $defaults;
+    }
+
+    /**
+     * @return array
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    /**
+     * @param array $options
+     */
+    public function setOptions(array $options)
+    {
+        $this->options = $options;
+    }
+
+    /**
+     * Get value from key
+     *
+     * @param $key
+     * @return array|mixed|null|string
+     */
+    public function get($key)
+    {
+        if (!array_key_exists($key, $this->options)) {
+            return null;
+        }
+
+        /** @var string|array|mixed $options */
+        $options = $this->options[$key];
+
+        return $options;
+    }
+}

--- a/src/Providers/RouteServiceProvider.php
+++ b/src/Providers/RouteServiceProvider.php
@@ -22,7 +22,7 @@ abstract class RouteServiceProvider extends ServiceProvider
     protected function registerAssets()
     {
         $this->publishes([
-            __DIR__ . '/config/optimus.components.php' => config_path('optimus.components.php'),
+            __DIR__ . '/../config/optimus.components.php' => config_path('optimus.components.php'),
         ]);
     }
 
@@ -38,7 +38,7 @@ abstract class RouteServiceProvider extends ServiceProvider
             return;
         }
 
-        $config->set('optimus.components', require __DIR__ . '/config/optimus.components.php');
+        $config->set('optimus.components', require __DIR__ . '/../config/optimus.components.php');
     }
     /**
      * Define the routes for the application.

--- a/src/Providers/RouteServiceProvider.php
+++ b/src/Providers/RouteServiceProvider.php
@@ -1,25 +1,13 @@
 <?php
 
-namespace Optimus\Api\System;
+namespace Optimus\Api\System\Providers;
 
 use Illuminate\Routing\Router;
 use Optimus\Api\System\Options\Config;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
 
-class RouteServiceProvider extends ServiceProvider
+abstract class RouteServiceProvider extends ServiceProvider
 {
-    /**
-     * Bootstrap any application services.
-     *
-     * @return void
-     */
-    public function boot()
-    {
-        $this->loadConfig();
-
-        parent::boot();
-    }
-
     /**
      * Register
      */
@@ -31,7 +19,7 @@ class RouteServiceProvider extends ServiceProvider
     /**
      * Register assets
      */
-    private function registerAssets()
+    protected function registerAssets()
     {
         $this->publishes([
             __DIR__ . '/config/optimus.components.php' => config_path('optimus.components.php'),
@@ -41,7 +29,7 @@ class RouteServiceProvider extends ServiceProvider
     /**
      * Load configuration
      */
-    private function loadConfig()
+    protected function loadConfig()
     {
         /** @var \Illuminate\Config\Repository $config */
         $config = $this->app['config'];

--- a/src/config/optimus.components.php
+++ b/src/config/optimus.components.php
@@ -5,6 +5,10 @@ return [
 
     ],
 
+    'middleware' => [
+
+    ],
+
     'protection_middleware' => [
 
     ],


### PR DESCRIPTION
- Individual providers for Laravel 5.2 and 5.3. Fixes https://github.com/esbenp/distributed-laravel/pull/2
- Added `'middleware'` config option for public routes
- Added config class `Optimus\Api\System\Options\Config`
This addition prevents the package from crashing in case of missing config keys.